### PR TITLE
ルートディレクトリからdeployment_pipelineをアップデートできるようにする

### DIFF
--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ deploy_pipeline:
 # === zip ===
 zip_lambda:
 	@if [ -z "$(file)" ]; then \
-		echo "use to: make zip_lambda file=file_name (拡張子なし)"; \
+		echo "Usage: make zip_lambda file=file_name (without extension)"; \
 		exit 1; \
 	fi
 	cd lambda && zip -j $(file).zip $(file).py

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: lint fmt all zip_lambda model_pipeline deploy_pipeline
+.PHONY: lint fmt all zip_lambda model_pipeline deploy_pipeline run_api
 # === Ruff ===
 
 lint:
@@ -24,3 +24,7 @@ zip_lambda:
 	fi
 	cd lambda && zip -j $(file).zip $(file).py
 	@echo "completed $(file).zip"
+
+# === API ===
+run_api:
+	poetry run uvicorn inference_api.main:app --reload --port 8000

--- a/makefile
+++ b/makefile
@@ -13,7 +13,7 @@ all: fmt lint
 model_pipeline:
 	poetry run python pipeline/model_pipeline/run_pipeline.py
 
-deploy_pipeline:
+deployment_pipeline:
 	poetry run python pipeline/deployment_pipeline/deployment_pipeline.py
 
 # === zip ===

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
-# Ruff を動作させる
-.PHONY: lint format all
+.PHONY: lint fmt all zip_lambda model_pipeline deploy_pipeline
+# === Ruff ===
 
 lint:
 	poetry run ruff check
@@ -9,17 +9,18 @@ fmt:
 
 all: fmt lint
 
-# Terraform をルートディレクトリから動作させる
-TF_DIR=terraform
+# === Pipeline ===
+model_pipeline:
+	poetry run python pipeline/model_pipeline/run_pipeline.py
 
-init:
-	terraform -chdir=$(TF_DIR) init
+deploy_pipeline:
+	poetry run python pipeline/deployment_pipeline/deployment_pipeline.py
 
-plan:
-	terraform -chdir=$(TF_DIR) plan
-
-apply:
-	terraform -chdir=$(TF_DIR) apply
-# brew install graphviz でインストールが必要(macOS)
-graph:
-	terraform -chdir=$(TF_DIR) graph | dot -Tpng > terraform_graph.png
+# === zip ===
+zip_lambda:
+	@if [ -z "$(file)" ]; then \
+		echo "use to: make zip_lambda file=file_name (拡張子なし)"; \
+		exit 1; \
+	fi
+	cd lambda && zip -j $(file).zip $(file).py
+	@echo "completed $(file).zip"

--- a/pipeline/deployment_pipeline/deployment_pipeline.py
+++ b/pipeline/deployment_pipeline/deployment_pipeline.py
@@ -80,7 +80,7 @@ endpoint_name = ParameterString("EndpointName", default_value="power-forecast-se
 
 deploy_lambda = Lambda(
     function_name="deploy-step",
-    zipped_code_dir="deploy_step.zip",
+    zipped_code_dir=str(Path(__file__).parent / "deploy_step.zip"),
     handler="deploy_step.lambda_handler",
     execution_role_arn=role,
     # TODO: 以下の渡し方だとエラーは出ないが、Lambdaの環境変数に渡せてない。今回はコンソール上から追加した


### PR DESCRIPTION
## 変更内容/概要

- ルートディレクトリからdeployment_pipelineをアップデートできるようにする
- makeファイルの更新
  - model_pipelineの実行
  - deployment_pipelineの更新
  - ローカルからapiの実行
  - lambdaフォルダにzipファイルの作成

## 変更理由

- いちいちディレクトの移動などをしてzipファイルなどを作成であったり実行することが面倒であったため

## 確認方法・動作確認

- ターミナル上で動作確認済み

## 関連issue・PR

- https://github.com/ryo19-96/power-forecasting-mlops/issues/29

## 参考リンク

- 
